### PR TITLE
add `__debugLiveStore` property to window / globalThis

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+import type { Store } from '@livestore/livestore';
+
+export {}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __debugLiveStore: Record<string, Store | undefined>;
+}


### PR DESCRIPTION
Hey, I noticed that the `__debugLiveStore` property on `window` does not exist like it is mentioned in the [LiveStore Docs](https://docs.livestore.dev/reference/store/#developmentdebugging-helpers).

The `@livestore/react` package [implements that](https://github.com/livestorejs/livestore/blob/dev/packages/%40livestore/react/src/LiveStoreProvider.tsx#L154-L158) for React, but this package does not.

I am by no means a Vue expert, so feel free to adjust the code. PR is open for edits.